### PR TITLE
Fix random bug with ObjectDict import.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def readme():
 
 setup(
     name="wsql_sdk",
-    version="0.3.8",
+    version="0.3.9",
     description='The chain of tools, that to make work with SQL easier',
     packages=["wsql_sdk", "wsql_sdk._lang"],
     requires=["pyparsing"],

--- a/wsql_sdk/codegen.py
+++ b/wsql_sdk/codegen.py
@@ -299,7 +299,7 @@ def process(args):
     builder = create_builder(args.language)
 
     modules = defaultdict(list)
-    has_union = dict()
+    has_union = defaultdict(lambda: False)
     for p in tokenizer.procedures():
         module, _, name = p.name.partition(args.sep)
         if len(name) == 0:
@@ -315,7 +315,7 @@ def process(args):
 
         module_name = procedure.module or "__init__"
         modules[module_name].append(procedure)
-        has_union[module_name] = p.return_mod == "union"
+        has_union[module_name] = p.return_mod == "union" or has_union[module_name]
 
     count = 0
     for module in modules:


### PR DESCRIPTION
Depending on order of procedures (which is random from `tokenizer.procedures()`), this code would overwrite `True` to `False` in `has_union` dict.
